### PR TITLE
Changing res.getHeader to res.headers

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -86,7 +86,9 @@ class TVDB
         callback new Error("Status: #{res.statusCode}")
         return
 
-      contentType = res.getHeader "content-type"
+      contentType = res.headers['content-type'];
+      if contentType.split(';').length
+        contentType = contentType.split(';')[0]
 
       dataBuffers = [ ]
       dataLen = 0

--- a/test/tvdb-api.test.coffee
+++ b/test/tvdb-api.test.coffee
@@ -23,8 +23,7 @@ describe "tvdb", ->
     http.get = (options, callback) ->
       callback
         statusCode: statusCode
-        getHeader: (which) ->
-          return contentType if which == "content-type"
+        headers: {'content-type': contentType}
         setEncoding: (encoding) -> return null
         on: (event, callback) ->
           switch event

--- a/test/tvdb.test.coffee
+++ b/test/tvdb.test.coffee
@@ -55,8 +55,7 @@ describe "tvdb", ->
         httpOptionsInterceptor options
         callback
           statusCode: statusCode
-          getHeader: (which) ->
-            return contentType if which == "content-type"
+          headers: {'content-type': contentType}
           setEncoding: (encoding) -> return null
           on: (event, callback) ->
             switch event


### PR DESCRIPTION
Can't find any references to getHeader being used on the client side. This commit changes to use the headers object and in the same time also handlers headers, such as "text/xml; charset=utf8"
