### PR TITLE
Added AirDay, AirTime, Runtime and Status to TV Shows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -451,7 +451,11 @@
         IMDB_ID: 'imdbId',
         zap2it_id: 'zap2itId',
         banner: 'banner',
-        Overview: 'overview'
+        Overview: 'overview',
+        Airs_DayOfWeek: 'airDay',
+        Airs_Time: 'airTime',
+        Runtime: 'runtime',
+        Status: 'status'
       };
       formattedTvShow = {
         id: tvShow.id,

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "node": ">=0.6.x <0.9"
   },
   "dependencies": {
-    "xml2js": "0.x",
+    "xml2js": "0.2.x",
     "underscore": "1.x",
     "adm-zip": "0.4.x"
   },
   "devDependencies": {
     "mocha": "1.x",
-    "coffee-script": "1.x",
+    "coffee-script": "1.6.x",
     "should": "0.x"
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -397,7 +397,8 @@ class TVDB
       done undefined, formattedResult
 
   formatTvShow: (tvShow) ->
-    keyMapping = IMDB_ID: 'imdbId', zap2it_id: 'zap2itId', banner: 'banner', Overview: 'overview'
+    keyMapping = IMDB_ID: 'imdbId', zap2it_id: 'zap2itId', banner: 'banner', Overview: 'overview', Airs_DayOfWeek: 'airDay', Airs_Time: 'airTime',
+    Runtime: 'runtime', Status: 'status'
     formattedTvShow =
       id: tvShow.id,
       genre: tvShow.Genre,

--- a/test/tvdb-api.test.coffee
+++ b/test/tvdb-api.test.coffee
@@ -227,7 +227,7 @@ describe "tvdb", ->
       dataFileUri = __dirname + "/data/series.single.xml"
       tvdb.getInfoTvShow "id", (err, tvShow) ->
         tvShow.id.should.equal "70327"
-        Object.getOwnPropertyNames(tvShow).length.should.equal 9
+        Object.getOwnPropertyNames(tvShow).length.should.equal 11
         done()
 
   describe "getInfoEpisode()", ->


### PR DESCRIPTION
Needed to modify the package.json to ensure the Xml2Js package was only
updating to the latest v0.2.x as there is a defect in 0.4.x where
malformed XML throws an exception. See this issue:
Leonidas-from-XIV/node-xml2js#118

There is also an issue using coffee script 1.7.x, the coffee script
only compiles going unto 1.6.x so I have made that modification also.
